### PR TITLE
Allow session data to be stored before the shutdown scripts execute

### DIFF
--- a/classes/VroomPlugin.php
+++ b/classes/VroomPlugin.php
@@ -63,6 +63,7 @@ class VroomPlugin
 
             // Ignore user aborts and allow the script to run forever
             ignore_user_abort(true);
+			session_write_close();
             set_time_limit(0);
 
             // Tell the browser that we are done


### PR DESCRIPTION
Sorry about the whitespace, can't figure out why github is making it different - it all lines up fine in my IDE's with various settings...
